### PR TITLE
dark theme: add some missing color definitions

### DIFF
--- a/theme-github-dark.css
+++ b/theme-github-dark.css
@@ -4,6 +4,7 @@
   --color-body: #373e47;
   --color-navbar: #22272e;
   --color-footer: #22272e;
+  --color-text-light: #a6aab5;
   --color-text-light-2: #adbac7;
   --color-text: #768390;
   --color-box-body: #22272e;
@@ -11,9 +12,47 @@
   --color-light: #22272e;
   --color-button: #22272e;
   --color-input-background: #22272e;
+  --color-input-text: #adbac7;
   --color-box-header: #22272e;
   --color-active: #22272e;
+  --color-menu: #22272e;
+  --color-secondary: #454a57;
 }
+
+.ui.list .list > .item > .content, .ui.list > .item > .content {
+  color: unset;
+}
+
+.ui.list .list > .item .description, .ui.list > .item .description {
+  color: var(--color-text);
+}
+
+.ui.repository.list, .ui.user.list {
+  background: var(--color-box-body);
+  padding: 1em;
+  border-radius: .75em;
+}
+
+.ui .error.header {
+  border-color: var(--color-red) !important;
+  background-color: var(--color-red) !important;
+  color: #ffffff !important;
+}
+
+.ui.modal > .header {
+  background: var(--color-secondary);
+  color: #dbdbdb;
+}
+
+.ui.modal > .actions {
+  background: var(--color-secondary);
+  border-color: var(--color-secondary);
+}
+
+.ui.modal > .content {
+  background: #383c4a;
+}
+
 .ui.green.buttons .button,
 .ui.green.button {
   background-color: #347d39;

--- a/theme-github-dark.css
+++ b/theme-github-dark.css
@@ -6,7 +6,7 @@
   --color-footer: #22272e;
   --color-text-light: #a6aab5;
   --color-text-light-2: #adbac7;
-  --color-text: #768390;
+  --color-text: #bbc0ca;
   --color-box-body: #22272e;
   --color-markup-code-block: #636e7b66;
   --color-light: #22272e;
@@ -31,6 +31,10 @@
   background: var(--color-box-body);
   padding: 1em;
   border-radius: .75em;
+}
+
+.ui.header .sub.header {
+  color: #636e7b;
 }
 
 .ui .error.header {


### PR DESCRIPTION
Thanks for your dark theme, which I really like!

Unfortunately at several places, the original/official light theme is shining through – this PR hopefully fixes most of them. There are probably still several things missing (the official dark theme, arc-green, theme has plenty more color definitions – some of those I "borrowed" here) – and there are places I was not able to fix (like label coloring on the main issues page, or in other places where they appear on dark ground: despite of the text color being applied directly to labels, some `!important` class definitions seem to overwrite that). Still I think this improves github-dark, so I decided to give something back. Hope you enjoy it.

PS: Tested on Gitea 1.15.3 with Waterfox.